### PR TITLE
[146] Show country source entity labels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,8 +45,8 @@ gem 'hashie', '~> 3.4', '>= 3.4.4'
 
 gem 'register_common', git: 'https://github.com/openownership/register-common.git'
 gem 'register_sources_oc', git: 'https://github.com/openownership/register-sources-oc.git'
-gem 'register_sources_psc', git: 'https://github.com/openownership/register-sources-psc.git', branch: 'raw-records-from-bods-identifiers'
-gem 'register_sources_bods', git: 'https://github.com/openownership/register-sources-bods.git', branch: 'bods-v2-prototype-fix-identifiers'
+gem 'register_sources_psc', git: 'https://github.com/openownership/register-sources-psc.git'
+gem 'register_sources_bods', git: 'https://github.com/openownership/register-sources-bods.git'
 
 group :development, :test do
   gem 'byebug', '~> 11.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-bods.git
-  revision: 49853c7f785bd04ac72f2c6b8f336a31a8997cc4
-  branch: bods-v2-prototype-fix-identifiers
+  revision: d57dc61474506b1bbc390a303927edba329e2ab1
   specs:
     register_sources_bods (0.1.0)
       activesupport (>= 6, < 8)
@@ -51,8 +50,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-psc.git
-  revision: 341ee042c0f6ad62516e3121d581daa29e9498db
-  branch: raw-records-from-bods-identifiers
+  revision: be9ffd1c7fc836753f1a1c014e051dac88ab19cb
   specs:
     register_sources_psc (0.1.0)
       activesupport (>= 6, < 8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-bods.git
-  revision: d57dc61474506b1bbc390a303927edba329e2ab1
+  revision: a707aa4d510ce564a13fb5c1095486a446601e42
   specs:
     register_sources_bods (0.1.0)
       activesupport (>= 6, < 8)
@@ -285,7 +285,7 @@ GEM
       sysexits (~> 1.1)
     hashdiff (1.0.1)
     hashie (3.6.0)
-    i18n (1.13.0)
+    i18n (1.14.0)
       concurrent-ruby (~> 1.0)
     i18n_data (0.13.1)
     ice_nine (0.11.2)

--- a/app/controllers/entities_controller.rb
+++ b/app/controllers/entities_controller.rb
@@ -128,6 +128,7 @@ class EntitiesController < ApplicationController
     @raw_data_records = RAW_DATA_RECORD_REPOSITORY.all_for_entity(entity) # .page(params[:page]).per(10)
     return if @raw_data_records.empty?
 
+    @oc_data = get_opencorporates_company_hash(entity) || {}
     @newest = RAW_DATA_RECORD_REPOSITORY.newest_for_entity(entity).data.notified_on # .updated_at
     @oldest = RAW_DATA_RECORD_REPOSITORY.oldest_for_entity(entity).data.notified_on # created_at
     @data_sources = DATA_SOURCE_REPOSITORY.all_for_entity(entity)

--- a/app/views/entities/raw.html.haml
+++ b/app/views/entities/raw.html.haml
@@ -17,10 +17,10 @@
                     = image_tag "icon-natural-person.svg"
                     = t("entity_types.natural-person").capitalize
               - else
-                - @sentity.jurisdiction_code.try do |entity_jurisdiction|
+                - @sentity.country.try do |country|
                   .jurisdiction
-                    = country_flag(@sentity.country)
-                    = entity_jurisdiction
+                    = country_flag(country)
+                    = entity_jurisdiction(@sentity)
                   .type-icon.legal-entity
                     = image_tag "icon-legal-entity.svg"
                     = glossary_tooltip(t("entity_types.legal-entity").capitalize, :'legal-entity', :right)
@@ -37,7 +37,7 @@
                 - @sentity.company_number.try do |company_number|
                   %h6= t("entities.show.fields.company_number")
                   %p= company_number
-                - @sentity.company_type.try do |company_type|
+                - @oc_data[:company_type].try do |company_type|
                   %h6= t("entities.show.fields.company_type")
                   %p= company_type
 

--- a/app/views/entities/show.html.haml
+++ b/app/views/entities/show.html.haml
@@ -20,10 +20,10 @@
                     = image_tag "icon-natural-person.svg"
                     = t("entity_types.natural-person").capitalize
               - else
-                - @sentity.jurisdiction_code.try do |entity_jurisdiction|
+                - @sentity.country.try do |country|
                   .jurisdiction
-                    = country_flag(@sentity.country)
-                    = entity_jurisdiction
+                    = country_flag(country)
+                    = entity_jurisdiction(@sentity)
                   .type-icon.legal-entity
                     = image_tag "icon-legal-entity.svg"
                     = glossary_tooltip(t("entity_types.legal-entity").capitalize, :'legal-entity', :right)


### PR DESCRIPTION
This fixes the accidental removal of company type from OpenCorporates data and the entity country's flag no longer being displayed on the entity show page or raw data page.

https://github.com/openownership/register/issues/146