### PR TITLE
Updated raw data repository for PSC fixes with source url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 
 GIT
   remote: https://github.com/openownership/register-sources-bods.git
-  revision: d412479d9c2dc0c106ad68dcc8fffca96bf35aad
+  revision: ef85e0a06f6c3e87672694554b1343e50f810cc9
   specs:
     register_sources_bods (0.1.0)
       activesupport (>= 6, < 8)
@@ -323,7 +323,7 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    minitest (5.18.0)
+    minitest (5.18.1)
     msgpack (1.6.0)
     multi_json (1.15.0)
     multipart-post (2.3.0)

--- a/app/repositories/raw_data_record_repository.rb
+++ b/app/repositories/raw_data_record_repository.rb
@@ -1,17 +1,43 @@
 require 'ostruct'
 require 'register_sources_psc/repositories/company_record_repository'
+require 'register_sources_bods/structs/identifier'
 
 class RawDataRecordRepository
   def initialize
     @repository = RegisterSourcesPsc::Repositories::CompanyRecordRepository.new
   end
 
-  def all_for_entity(entity)
-    bods_identifiers = entity.identifiers # identifier_converter.convert_v1_to_v2 entity.identifiers
+  def all_for_entity(main_entity)
+    return all_for_entity(main_entity.master_entity) if main_entity.master_entity
+
+    bods_identifiers = []
+
+    [
+      main_entity,
+      main_entity.relationships_as_source,
+      main_entity.relationships_as_target
+    ].flatten.map(&:bods_statement).each do |bods_statement|
+      if bods_statement.respond_to?(:identifiers)
+        bods_identifiers += bods_statement.identifiers
+      end
+
+      if bods_statement.respond_to?(:source)
+        source = bods_statement.source
+        if source
+          s = source.url.to_s.split("https://api.company-information.service.gov.uk")
+          if s.length > 1
+            bods_identifiers += [RegisterSourcesBods::Identifier.new(
+              schemeName: 'GB Persons Of Significant Control Register',
+              id: s[1]
+            )]
+          end
+        end
+      end
+    end
 
     return [] if bods_identifiers.empty?
 
-    get_by_bods_identifiers(bods_identifiers) # .order_by(updated_at: :desc, created_at: :desc)
+    get_by_bods_identifiers(bods_identifiers.uniq) # .order_by(updated_at: :desc, created_at: :desc)
   end
 
   def newest_for_entity(entity)


### PR DESCRIPTION
Added using source URL to fetch the original source PSC records from the PSC repository, from BODS v0.2 records.