### PR TITLE
[#163] build: add configure-dev-lib script, for local gem overrides

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,6 +13,7 @@ free to contact us on: tech@openownership.org and we'd be happy to advise.
 
 - [Installation](#installation)
 - [Testing](#testing)
+- [Development](#development)
 - [Code overview](#code-overview)
 - [A note on issue tracking](#a-note-on-issue-tracking)
 - [A note on Git history](#a-note-on-git-history)
@@ -106,6 +107,24 @@ Run the tests:
 ```sh
 bin/test
 ```
+
+## Development
+
+### Docker
+
+The app depends on a number of [Open Ownership](https://github.com/openownership) libraries which are included as Ruby gems in `Gemfile`. If working on code which spans multiple repositories, it can be convenient to be able to override the libraries and mount your latest code. To do so:
+
+Uncomment the extra lib volumes in `docker-compose.yml`, pointing to the libraries' repositories.
+
+Execute the `configure-dev-lib` script to configure Bundler:
+
+```sh
+docker compose exec web configure-dev-lib
+```
+
+Restart the services. Note that changes to local gem libraries do not get automatically detected, so if you need them to update, restart the services on demand.
+
+If you want to restore things to their clean state, simply rebuild and restart the services.
 
 ## Code overview
 

--- a/bin/configure-dev-lib
+++ b/bin/configure-dev-lib
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+bundle config disable_local_branch_check true
+
+bundle config local.register_common       lib/register-common
+bundle config local.register_sources_bods lib/register-sources-bods
+bundle config local.register_sources_oc   lib/register-sources-oc
+bundle config local.register_sources_psc  lib/register-sources-psc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,9 @@ services:
       - ./package.json:/home/x/r/package.json
       - ./spec:/home/x/r/spec
       - ./yarn.lock:/home/x/r/yarn.lock
+      #- ../register-common:/home/x/r/lib/register-common
+      #- ../register-sources-bods:/home/x/r/lib/register-sources-bods
+      #- ../register-sources-oc:/home/x/r/lib/register-sources-oc
+      #- ../register-sources-psc:/home/x/r/lib/register-sources-psc
 networks:
   web: {}


### PR DESCRIPTION
This does not address the actual task. However, it makes looking into it far easier, as it's possible to set up Bundler for local gems with a single command. This will also be useful for other cross-repo work.

This wouldn't be necessary with Git Submodules… ;)