### PR TITLE
build: disable Elasticsearch X-Pack security explicitly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
     environment:
       ES_JAVA_OPTS: -Xms512m -Xmx512m
       discovery.type: single-node
+      xpack.security.enabled: 'false'
     healthcheck:
       interval: 5s
       retries: 6


### PR DESCRIPTION
Otherwise, this results in constant warnings:

    warning: 299 Elasticsearch-7.17.6-f65e9d338dc1d07b642e14a27f338990148ee5b6 "Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security."

I shouldn't've removed this setting when reworking Elasticsearch within Docker.

cc @StephenAbbott 