### PR TITLE
ci: fix by removing ChromeDriver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
       - checkout
       
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
 
       # Which version of bundler?
       - run:


### PR DESCRIPTION
I don't believe this is used in register-v2.